### PR TITLE
Add balanceOf() function

### DIFF
--- a/contracts/TokenLock.sol
+++ b/contracts/TokenLock.sol
@@ -12,7 +12,8 @@ contract TokenLock is OwnableUpgradeable {
   string public name;
   string public symbol;
   uint256 public totalSupply;
-  mapping(address => uint256) public balanceOf;
+
+  mapping(address => uint256) private balance;
 
   event Deposit(address indexed holder, uint256 amount);
   event Withdrawal(address indexed holder, uint256 amount);
@@ -50,7 +51,7 @@ contract TokenLock is OwnableUpgradeable {
     }
 
     token.transferFrom(msg.sender, address(this), amount);
-    balanceOf[msg.sender] += amount;
+    balance[msg.sender] += amount;
     totalSupply += amount;
 
     emit Deposit(msg.sender, amount);
@@ -65,11 +66,11 @@ contract TokenLock is OwnableUpgradeable {
     ) {
       revert LockPeriodOngoing();
     }
-    if (balanceOf[msg.sender] < amount) {
+    if (balance[msg.sender] < amount) {
       revert ExceedsBalance();
     }
 
-    balanceOf[msg.sender] -= amount;
+    balance[msg.sender] -= amount;
     totalSupply -= amount;
     token.transfer(msg.sender, amount);
 
@@ -79,5 +80,11 @@ contract TokenLock is OwnableUpgradeable {
   /// @dev Returns the number of decimals of the locked token
   function decimals() public view returns (uint8) {
     return token.decimals();
+  }
+
+  /// @dev Returns the balance of a given address
+  /// @param _owner The address whose balance should be checked
+  function balanceOf(address _owner) public view returns (uint256) {
+    return balance[_owner];
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@nomiclabs/hardhat-waffle": "2.0.1",
     "@openzeppelin/hardhat-upgrades": "1.12.0",
     "@typechain/ethers-v5": "8.0.5",
-    "@typechain/hardhat": "3.1.0",
+    "@typechain/hardhat": "^3.1.0",
     "@types/chai": "4.3.0",
     "@types/dotenv": "8.2.0",
     "@types/mocha": "9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1251,7 +1251,7 @@
   dependencies:
     ethers "^5.0.2"
 
-"@typechain/hardhat@3.1.0":
+"@typechain/hardhat@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@typechain/hardhat/-/hardhat-3.1.0.tgz#88bd9e9d55e30fbece6fbb34c03ecd40a8b2013a"
   integrity sha512-C6Be6l+vTpao19PvMH2CB/lhL1TRLkhdPkvQCF/zqkY1e+0iqY2Bb9Jd3PTt6I8QvMm89ZDerrCJC9927ZHmlg==


### PR DESCRIPTION
This PR adds a `balanceOf()` function, as the previous `balanceOf` mapping would not have been compatible with wallets and other UIs expective the ERC20 compliant `balanceOf()` function.