### PR TITLE
Change to new RPC endpoint

### DIFF
--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -36,7 +36,7 @@ export const CHAINS: Chain[] = [
       name: "xDai",
       symbol: "xDAI",
     },
-    rpcUrls: ["https://rpc.xdaichain.com/"],
+    rpcUrls: ["https://rpc.gnosischain.com/"],
     blockExplorers: [
       { name: "Blockscout", url: "https://blockscout.com/xdai/mainnet" },
     ],


### PR DESCRIPTION
The frontend doesnt load the balance of the user because it still uses the old rpc endpoint. Therefore replace the old endpoint with the new one ( "https://rpc.gnosischain.com/" ) 

Error message:

Access to fetch at 'https://rpc.xdaichain.com/' from origin 'https://lock.gnosis.io' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.